### PR TITLE
Change API for `truncate` and add `size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0
+
+- Changed API for `truncate` in order to make it more flexible.
+- Added `size` for estimating the size in bytes of an object.
+
 # 1.10.0
 
 - Added `removeFn` to `compact` for arbitrary removal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # 2.0.0
 
-- Changed API for `truncate` in order to make it more flexible.
-- Added `size` for estimating the size in bytes of an object.
+-   BREAKING CHANGE: Changed API for `truncate` in order to make it more flexible.
+-   Added `size` for estimating the size in bytes of an object.
 
 # 1.10.0
 
-- Added `removeFn` to `compact` for arbitrary removal.
+-   Added `removeFn` to `compact` for arbitrary removal.
 
 # 1.9.0
 
-- Added `objectsOnly` option to `flatten`.
+-   Added `objectsOnly` option to `flatten`.
 
 # 1.8.0
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ logical way. Prefer `walkie` in these scenarios.
 `map`, `walkie`, `walkieAsync`, `mapLeaves`, `compact`, and `truncate` support
 the option `modifyInPlace` for in-place modification. Otherwise, the object is deep cloned.
 
+```typescript
+export interface MutationOption {
+    /** Set to true to modify the object instead of returning a new object. */
+    modifyInPlace?: boolean
+}
+```
+
 ## walker
 
 ```typescript
@@ -155,7 +162,7 @@ Produces:
 ## walkie
 
 ```typescript
-walkie(obj: object, walkFn: WalkFn, options: WalkOptions = {}) => object
+walkie(obj: object, walkFn: WalkFn, options: options?: WalkOptions & MutationOption) => object
 ```
 
 ```typescript
@@ -261,7 +268,7 @@ Undefined array values will not be excluded. To customize
 pass a fn for `options.shouldSkip`.
 
 ```typescript
-map(obj: object, mapper: Mapper, options: MapOptions = {}) => object
+map(obj: object, mapper: Mapper, options?: MapOptions & MutationOption) => object
 ```
 
 ```typescript
@@ -508,7 +515,7 @@ Produces:
 ## compact
 
 ```typescript
-compact(obj: object, options: CompactOptions) => object
+compact(obj: object, options: CompactOptions & MutationOption) => object
 ```
 
 ```typescript
@@ -567,19 +574,33 @@ Produces:
 ## truncate
 
 ```typescript
-truncate(obj: object, options: TruncateOptions) => object
+truncate(obj: object, options: TruncateOptions & MutationOption) => object
 ```
 
 ```typescript
-interface TruncateOptions {
-    depth: number
-    replaceWith?: any
+export interface TruncateOptions {
+    /** Max allowed depth of objects/arrays. Default to Infinity */
+    maxDepth?: number
+    /** What to replace an object/array at the maximum depth with. Defaults to '[Truncated]' */
+    replacementAtMaxDepth?: any
+    /** Max allowed length of a string. Defaults to Infinity */
+    maxStringLength?: number
+    /** What to replace the last characters of the truncated string with. Defaults to '...' */
+    replacementAtMaxStringLength?: string
+    /** Max allowed length of an array. Defaults to Infinity */
+    maxArrayLength?: number
+    /** Transform instances of Error into plain objects so that truncation can be performed. Defautls to false */
+    transformErrors?: boolean
 }
 ```
 
-Truncate an object replacing nested objects at depth greater
-than the max specified depth with `replaceWith`. Replace text Defaults
-to `[Truncated]`.
+Truncate allows you to limit the depth of nested objects/arrays,
+the length of strings, and the length of arrays. Instances of Error
+can be converted to plain objects so that the enabled truncation options
+also apply to the error fields. All truncation methods are opt-in.
+
+Note: For the best performance you should consider setting `modifyInPlace`
+to `true`.
 
 ```typescript
 const obj = {
@@ -606,6 +627,29 @@ Produces:
   },
   f: 42,
 }
+```
+
+## size
+
+```typescript
+size(obj: object) => number
+```
+
+Estimate the size of an object in bytes.
+
+```typescript
+const obj = {
+    a: {
+        b: 'hello',
+    },
+    c: Symbol('hello'),
+    d: {
+        e: [true, false],
+    },
+    f: [42, 10n],
+}
+size(obj)
+// 44
 ```
 
 ## Helper fns

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj-walker",
-  "version": "1.10.0",
+  "version": "2.0.0",
   "description": "Walk or map over objects in a depth-first preorder or postorder manner.",
   "author": "David Sargeant",
   "repository": "git://github.com/dubiousdavid/obj-walker.git",
@@ -37,7 +37,8 @@
     "remove",
     "truncate",
     "async",
-    "modify"
+    "modify",
+    "size"
   ],
   "license": "ISC",
   "prettier": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,7 +114,7 @@ export interface TruncateOptions {
   replacementAtMaxStringLength?: string
   /** Max allowed length of an array. Defaults to Infinity */
   maxArrayLength?: number
-  /** Transform instances of Error into plain objects so that truncation can be performed. Defautls to false */
+  /** Transform instances of Error into plain objects so that truncation can be performed. Defaults to false */
   transformErrors?: boolean
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,13 +104,18 @@ export type Compact = (
 ) => object
 
 export interface TruncateOptions {
-  depth: number
-  /** Defaults to [Truncated] */
-  replaceWith?: any
-  /** Max length of a string. Default to Infinity. */
-  stringLength?: number
-  /** Max length of an array */
-  arrayLength?: number
+  /** Max allowed depth of objects/arrays. Default to Infinity */
+  maxDepth?: number
+  /** What to replace an object/array at the maximum depth with. Defaults to '[Truncated]' */
+  replacementAtMaxDepth?: any
+  /** Max allowed length of a string. Defaults to Infinity */
+  maxStringLength?: number
+  /** What to replace the last characters of the truncated string with. Defaults to '...' */
+  replacementAtMaxStringLength?: string
+  /** Max allowed length of an array. Defaults to Infinity */
+  maxArrayLength?: number
+  /** Transform instances of Error into plain objects so that truncation can be performed. Defautls to false */
+  transformErrors?: boolean
 }
 
 export type Truncate = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,7 +104,7 @@ export type Compact = (
 ) => object
 
 export interface TruncateOptions {
-  /** Max allowed depth of objects/arrays. Default to Infinity */
+  /** Max allowed depth of objects/arrays. Defaults to Infinity */
   maxDepth?: number
   /** What to replace an object/array at the maximum depth with. Defaults to '[Truncated]' */
   replacementAtMaxDepth?: any

--- a/src/util.ts
+++ b/src/util.ts
@@ -31,3 +31,22 @@ export const getRoot = (obj: object, jsonCompat = false): Node => {
     ? { key: '', val: obj, parents: [{ '': obj }], ...rootCommon }
     : { key: undefined, val: obj, parents: [], ...rootCommon }
 }
+
+/**
+ * Size in bytes
+ */
+export const ECMA_SIZES = {
+  STRING: 2,
+  BOOLEAN: 4,
+  BYTES: 4,
+  NUMBER: 8,
+  Int8Array: 1,
+  Uint8Array: 1,
+  Uint8ClampedArray: 1,
+  Int16Array: 2,
+  Uint16Array: 2,
+  Int32Array: 4,
+  Uint32Array: 4,
+  Float32Array: 4,
+  Float64Array: 8,
+}

--- a/src/walker.test.ts
+++ b/src/walker.test.ts
@@ -1415,7 +1415,7 @@ describe('truncate', () => {
       },
     })
   })
-  test('should truncate long strings', () => {
+  test('should truncate strings', () => {
     const obj = {
       a: {
         b: '1234567890',
@@ -1427,7 +1427,7 @@ describe('truncate', () => {
     const result = truncate(obj, { maxStringLength: 5 })
     expect(result).toEqual({ a: { b: '12345...' }, c: '123', d: 42, e: null })
   })
-  test('should truncate long strings with custom replacement text', () => {
+  test('should truncate strings with custom replacement text', () => {
     const obj = {
       a: {
         b: '1234567890',
@@ -1442,7 +1442,7 @@ describe('truncate', () => {
     })
     expect(result).toEqual({ a: { b: '12345' }, c: '123', d: 42, e: null })
   })
-  test('should truncate long arrays', () => {
+  test('should truncate arrays', () => {
     const obj = {
       a: [1, 2, 3, 4, 5],
       c: '123',

--- a/src/walker.test.ts
+++ b/src/walker.test.ts
@@ -1510,4 +1510,13 @@ describe('size', () => {
     const result = size(obj)
     expect(result).toBe(44)
   })
+  test('should return 0 bytes if there are no leaf nodes', () => {
+    const obj = {
+      a: {
+        b: {},
+      },
+    }
+    const result = size(obj)
+    expect(result).toBe(0)
+  })
 })

--- a/src/walker.test.ts
+++ b/src/walker.test.ts
@@ -12,6 +12,7 @@ import {
   truncate,
   walkieAsync,
   SHORT_CIRCUIT,
+  size,
 } from './walker'
 import { parentIsArray } from './util'
 import { Node } from './types'
@@ -1306,7 +1307,7 @@ describe('truncate', () => {
       d: 42,
       e: null,
     }
-    const result = truncate(obj, { depth: 1 })
+    const result = truncate(obj, { maxDepth: 1 })
     expect(result).toEqual({
       a: '[Truncated]',
       c: 'Bob',
@@ -1327,7 +1328,7 @@ describe('truncate', () => {
       },
       f: 42,
     }
-    const result = truncate(obj, { depth: 2 })
+    const result = truncate(obj, { maxDepth: 2 })
     expect(result).toEqual({
       a: {
         b: 'Frank',
@@ -1348,7 +1349,7 @@ describe('truncate', () => {
       },
       f: 42,
     }
-    const result = truncate(obj, { depth: 4 })
+    const result = truncate(obj, { maxDepth: 4 })
     expect(result).toEqual({
       a: { b: 'Frank', c: { d: ['Bob', '[Truncated]', 'Tom'] }, e: null },
       f: 42,
@@ -1363,7 +1364,7 @@ describe('truncate', () => {
       d: 42,
       e: null,
     }
-    const result = truncate(obj, { depth: 1, replaceWith: null })
+    const result = truncate(obj, { maxDepth: 1, replacementAtMaxDepth: null })
     expect(result).toEqual({
       a: null,
       c: 'Bob',
@@ -1380,7 +1381,7 @@ describe('truncate', () => {
       d: 42,
       e: null,
     }
-    const result = truncate(obj, { depth: 1, modifyInPlace: true })
+    const result = truncate(obj, { maxDepth: 1, modifyInPlace: true })
     expect(result).toEqual({
       a: '[Truncated]',
       c: 'Bob',
@@ -1405,7 +1406,7 @@ describe('truncate', () => {
     const obj = {
       error,
     }
-    const result = truncate(obj, { depth: 5 })
+    const result = truncate(obj, { maxDepth: 5, transformErrors: true })
     expect(result).toMatchObject({
       error: {
         message: 'failure',
@@ -1423,8 +1424,23 @@ describe('truncate', () => {
       d: 42,
       e: null,
     }
-    const result = truncate(obj, { depth: 5, stringLength: 5 })
+    const result = truncate(obj, { maxStringLength: 5 })
     expect(result).toEqual({ a: { b: '12345...' }, c: '123', d: 42, e: null })
+  })
+  test('should truncate long strings with custom replacement text', () => {
+    const obj = {
+      a: {
+        b: '1234567890',
+      },
+      c: '123',
+      d: 42,
+      e: null,
+    }
+    const result = truncate(obj, {
+      maxStringLength: 5,
+      replacementAtMaxStringLength: '',
+    })
+    expect(result).toEqual({ a: { b: '12345' }, c: '123', d: 42, e: null })
   })
   test('should truncate long arrays', () => {
     const obj = {
@@ -1433,12 +1449,65 @@ describe('truncate', () => {
       d: [1, 2],
       e: null,
     }
-    const result = truncate(obj, { depth: 5, arrayLength: 3 })
+    const result = truncate(obj, { maxArrayLength: 3 })
     expect(result).toEqual({
       a: [1, 2, 3],
       c: '123',
       d: [1, 2],
       e: null,
     })
+  })
+})
+
+describe('size', () => {
+  test('should return number of bytes for strings', () => {
+    const obj = {
+      a: {
+        b: 'hello',
+      },
+    }
+    const result = size(obj)
+    expect(result).toBe(10)
+  })
+  test('should return number of bytes for symbols', () => {
+    const obj = {
+      a: {
+        b: Symbol('hello'),
+      },
+    }
+    const result = size(obj)
+    expect(result).toBe(10)
+  })
+  test('should return number of bytes for booleans', () => {
+    const obj = {
+      a: {
+        b: [true, false],
+      },
+    }
+    const result = size(obj)
+    expect(result).toBe(8)
+  })
+  test('should return number of bytes for numbers', () => {
+    const obj = {
+      a: {
+        b: [42, 10n],
+      },
+    }
+    const result = size(obj)
+    expect(result).toBe(16)
+  })
+  test('should return number of bytes for mixed types', () => {
+    const obj = {
+      a: {
+        b: 'hello',
+      },
+      c: Symbol('hello'),
+      d: {
+        e: [true, false]
+      },
+      f: [42, 10n]
+    }
+    const result = size(obj)
+    expect(result).toBe(44)
   })
 })

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -23,6 +23,7 @@ import {
   defTraverse,
   getRoot,
   parentIsArray,
+  ECMA_SIZES,
 } from './util'
 
 const nextNode: NextNode = (currentNode, entry, isLeaf) => {
@@ -400,22 +401,6 @@ export const truncate: Truncate = (obj, options) => {
     },
     options
   )
-}
-
-const ECMA_SIZES = {
-  STRING: 2,
-  BOOLEAN: 4,
-  BYTES: 4,
-  NUMBER: 8,
-  Int8Array: 1,
-  Uint8Array: 1,
-  Uint8ClampedArray: 1,
-  Int16Array: 2,
-  Uint16Array: 2,
-  Int32Array: 4,
-  Uint32Array: 4,
-  Float32Array: 4,
-  Float64Array: 8,
 }
 
 /**

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -364,12 +364,12 @@ export const compact: Compact = (obj, options) => {
  */
 export const truncate: Truncate = (obj, options) => {
   const maxDepth = options.maxDepth || Infinity
-  const maxStringLength = options.maxStringLength || Infinity
-  const maxArrayLength = options.maxArrayLength || Infinity
   const replacementAtMaxDepth =
     'replacementAtMaxDepth' in options
       ? options.replacementAtMaxDepth
       : '[Truncated]'
+  const maxArrayLength = options.maxArrayLength || Infinity
+  const maxStringLength = options.maxStringLength || Infinity
   const replacementAtMaxStringLength =
     options.replacementAtMaxStringLength ?? '...'
   return map(
@@ -379,6 +379,10 @@ export const truncate: Truncate = (obj, options) => {
       // Max depth reached
       if (!isLeaf && path.length === maxDepth) {
         return replacementAtMaxDepth
+      }
+      // Array exceeds max length
+      if (Array.isArray(val) && val.length > maxArrayLength) {
+        return val.slice(0, maxArrayLength)
       }
       // Transform Error to plain object
       if (options.transformErrors && val instanceof Error) {
@@ -392,10 +396,6 @@ export const truncate: Truncate = (obj, options) => {
       // String exceeds max length
       if (typeof val === 'string' && val.length > maxStringLength) {
         return `${val.slice(0, maxStringLength)}${replacementAtMaxStringLength}`
-      }
-      // Array exceeds max length
-      if (Array.isArray(val) && val.length > maxArrayLength) {
-        return val.slice(0, maxArrayLength)
       }
       return val
     },

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -363,9 +363,9 @@ export const compact: Compact = (obj, options) => {
  * Inspiration: https://github.com/runk/dtrim
  */
 export const truncate: Truncate = (obj, options) => {
-  const depth = options.maxDepth || Infinity
-  const stringLength = options.maxStringLength || Infinity
-  const arrayLength = options.maxArrayLength || Infinity
+  const maxDepth = options.maxDepth || Infinity
+  const maxStringLength = options.maxStringLength || Infinity
+  const maxArrayLength = options.maxArrayLength || Infinity
   const replacementAtMaxDepth =
     'replacementAtMaxDepth' in options
       ? options.replacementAtMaxDepth
@@ -377,7 +377,7 @@ export const truncate: Truncate = (obj, options) => {
     (node) => {
       const { path, val, isLeaf } = node
       // Max depth reached
-      if (!isLeaf && path.length === depth) {
+      if (!isLeaf && path.length === maxDepth) {
         return replacementAtMaxDepth
       }
       // Transform Error to plain object
@@ -390,12 +390,12 @@ export const truncate: Truncate = (obj, options) => {
         }
       }
       // String exceeds max length
-      if (typeof val === 'string' && val.length > stringLength) {
-        return `${val.slice(0, stringLength)}${replacementAtMaxStringLength}`
+      if (typeof val === 'string' && val.length > maxStringLength) {
+        return `${val.slice(0, maxStringLength)}${replacementAtMaxStringLength}`
       }
       // Array exceeds max length
-      if (Array.isArray(val) && val.length > arrayLength) {
-        return val.slice(0, arrayLength)
+      if (Array.isArray(val) && val.length > maxArrayLength) {
+        return val.slice(0, maxArrayLength)
       }
       return val
     },

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -410,8 +410,10 @@ const getSize = (value: any): number => {
   if (typeof value === 'boolean') {
     return ECMA_SIZES.BYTES
   } else if (typeof value === 'string') {
+    // Strings are encoded using UTF-16
     return value.length * ECMA_SIZES.STRING
   } else if (typeof value === 'number') {
+    // Numbers are 64-bit
     return ECMA_SIZES.NUMBER
   } else if (typeof value === 'symbol' && value.description) {
     return value.description.length * ECMA_SIZES.STRING


### PR DESCRIPTION
- Changed API for `truncate` in order to make it more flexible.
- Added `size` for estimating the size in bytes of an object.