### PR TITLE
Unflatten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.2.0
+
+-   Added `unflatten` to compliment `flatten`.
+-   Deprecated `walkie`. Use `walkEach`.
+-   Deprecated `walkieAsync`. Use `walkEachAsync`.
+
 # 2.1.0
 
 -   Added handling of top-level scalar values to `size`.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ option to `true`.
 
 Custom traversal functions are supported for some functions. This allows you
 to walk tree-like structures, such as a JSON schema, in a more efficient and
-logical way. Prefer `walkie` in these scenarios.
+logical way. Prefer `walkEach` in these scenarios.
 
-`map`, `walkie`, `walkieAsync`, `mapLeaves`, `compact`, and `truncate` support
+`map`, `walkEach`, `walkEachAsync`, `mapLeaves`, `compact`, and `truncate` support
 the option `modifyInPlace` for in-place modification. Otherwise, the object is deep cloned.
 
 ```typescript
@@ -159,17 +159,15 @@ Produces:
 ]
 ```
 
-## walkie
+## walkEach
 
 ```typescript
-walkie(obj: object, walkFn: WalkFn, options: options?: WalkOptions & MutationOption) => object
+walkEach(obj: object, walkFn: WalkFn, options: options?: WalkOptions & MutationOption) => object
 ```
 
 ```typescript
 export type WalkFn = (node: Node) => void
 ```
-
-Walk-each ~ walkie
 
 Walk over an object calling `walkFn` for each node. The original
 object is deep-cloned by default making it possible to simply mutate each
@@ -181,7 +179,7 @@ wherever it exists. I traverse this tree using a custom `traverse` fn.
 The original object is not modified.
 
 ```typescript
-import { walkie } from 'obj-walker'
+import { walkEach } from 'obj-walker'
 
 const obj = {
     bsonType: 'object',
@@ -218,7 +216,7 @@ const walkFn = ({ val }: Node) => {
         val.additionalProperties = true
     }
 }
-walkie(obj, walkFn, { traverse })
+walkEach(obj, walkFn, { traverse })
 ```
 
 Produces:
@@ -252,9 +250,9 @@ Produces:
 }
 ```
 
-## walkieAsync
+## walkEachAsync
 
-Like `walkie` but awaits the promise returned by `walkFn` before proceeding to
+Like `walkEach` but awaits the promise returned by `walkFn` before proceeding to
 the next node.
 
 ## map
@@ -509,6 +507,53 @@ Produces:
   'd.f.0': 10,
   'd.f.1': 20,
   'd.f.2': 30,
+}
+```
+
+## unflatten
+
+```typescript
+unflatten(obj: object, options?: UnflattenOptions) => object
+```
+
+```typescript
+interface UnflattenOptions {
+    /** Defaults to '.' */
+    separator?: string | RegExp
+}
+```
+
+Unflatten an object previously flattened. Optionally pass `separator`
+to determine what character or RegExp to split keys with.
+Defaults to '.'.
+
+```typescript
+import { unflatten } from 'obj-walker'
+
+const obj = {
+    'a.b': 23,
+    'a.c': 24,
+    'd.e': 100,
+    'd.f.0': 10,
+    'd.f.1': 20,
+    'd.f.2.g': 30,
+    'd.f.2.h.i': 40,
+}
+unflatten(obj)
+```
+
+Produces:
+
+```typescript
+{
+  a: {
+    b: 23,
+    c: 24,
+  },
+  d: {
+    e: 100,
+    f: [10, 20, { g: 30, h: { i: 40 } }],
+  },
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obj-walker",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obj-walker",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "json-decycle": "^2.0.1",
@@ -18,7 +18,7 @@
         "@typescript-eslint/eslint-plugin": "^5.26.0",
         "eslint": "^8.16.0",
         "jest": "^28.1.0",
-        "prettier": "^2.6.2",
+        "prettier": "^3.2.5",
         "ts-jest": "^28.0.3",
         "ts-node": "^10.8.0",
         "typescript": "^4.7.2"
@@ -4283,15 +4283,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -8345,9 +8345,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj-walker",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Walk or map over objects in a depth-first preorder or postorder manner.",
   "author": "David Sargeant",
   "repository": "git://github.com/dubiousdavid/obj-walker.git",
@@ -30,6 +30,7 @@
     "pointer",
     "ref",
     "flatten",
+    "unflatten",
     "find",
     "leaves",
     "traverse",
@@ -56,7 +57,7 @@
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "eslint": "^8.16.0",
     "jest": "^28.1.0",
-    "prettier": "^2.6.2",
+    "prettier": "^3.2.5",
     "ts-jest": "^28.0.3",
     "ts-node": "^10.8.0",
     "typescript": "^4.7.2"

--- a/src/refs.ts
+++ b/src/refs.ts
@@ -1,5 +1,5 @@
 import { decycle, retrocycle } from 'json-decycle'
-import { walkie, map } from './walker'
+import { walkEach, map } from './walker'
 import { Node, RefOptions } from './types'
 
 /**
@@ -22,5 +22,5 @@ export const deref = (obj: object, options?: RefOptions) => {
   const walkFn = ({ parents, key, val }: Node) => {
     fn.call(parents[0], key ?? '', val)
   }
-  return walkie(obj, walkFn, { ...options, postOrder: true, jsonCompat: true })
+  return walkEach(obj, walkFn, { ...options, postOrder: true, jsonCompat: true })
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,13 +44,13 @@ export type Walker = (obj: object, walkFn: WalkFn, options?: Options) => void
 
 export type Walk = (obj: object, options?: WalkOptions) => Node[]
 
-export type Walkie = (
+export type WalkEach = (
   obj: object,
   walkFn: WalkFn,
   options?: WalkOptions & MutationOption
 ) => object
 
-export type WalkieAsync = (
+export type WalkEachAsync = (
   obj: object,
   walkFn: AsyncWalkFn,
   options?: WalkOptions & MutationOption
@@ -85,6 +85,13 @@ export type Flatten = (
   obj: object,
   options?: WalkOptions & FlattenOptions
 ) => object
+
+export interface UnflattenOptions {
+  /** Defaults to '.' */
+  separator?: string | RegExp
+}
+
+export type Unflatten = (obj: object, options?: UnflattenOptions) => object
 
 export interface CompactOptions {
   removeUndefined?: boolean


### PR DESCRIPTION
-   Added `unflatten` to compliment `flatten`.
-   Deprecated `walkie`. Use `walkEach`.
-   Deprecated `walkieAsync`. Use `walkEachAsync`.