### PR TITLE
`flatten` properly handles alphanumeric keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.5.1
-- `chunkPath` - Exported utility function for chunking paths, joining consecutive non-numeric keys and keeping numeric keys separate.
-- Fixed `chunkPath` regex to match only keys that are entirely numeric (not keys containing numbers).
+
+- Fixed issue with `flatten` and the `objectsOnly` option when keys contained alpha and numeric characters.
 
 # 2.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.5.1
+- `chunkPath` - Exported utility function for chunking paths, joining consecutive non-numeric keys and keeping numeric keys separate.
+- Fixed `chunkPath` regex to match only keys that are entirely numeric (not keys containing numbers).
+
 # 2.5.0
 
 - `exclude` - Exclude one or more paths, optionally using star patterns, from an object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obj-walker",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obj-walker",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obj-walker",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Walk or map over objects in a depth-first preorder or postorder manner.",
   "author": "David Sargeant",
   "repository": "git://github.com/smartprocure/obj-walker.git",

--- a/src/walker.test.ts
+++ b/src/walker.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest'
 import { Node } from './types'
 import { parentIsArray } from './util'
 import {
+  chunkPath,
   compact,
   exclude,
   findNode,
@@ -1432,5 +1433,28 @@ describe('exclude', () => {
       ],
       settings: { theme: 'dark' },
     })
+  })
+})
+
+describe('chunkPath', () => {
+  const separator = '.'
+  test('should return empty array for empty path', () => {
+    expect(chunkPath([], separator)).toEqual([])
+  })
+
+  test('should join consecutive non-numeric keys', () => {
+    expect(chunkPath(['a', 'b', 'c'], separator)).toEqual(['a.b.c'])
+  })
+
+  test('should keep numeric keys as separate chunks', () => {
+    expect(chunkPath(['a', 'b', '0'], separator)).toEqual(['a.b', '0'])
+    expect(chunkPath(['0', 'a', 'b'], separator)).toEqual(['0', 'a.b'])
+    expect(chunkPath(['a', '0', 'b'], separator)).toEqual(['a', '0', 'b'])
+  })
+
+  test('should handle keys that contain numbers', () => {
+    expect(chunkPath(['a1', 'b2'], separator)).toEqual(['a1.b2'])
+    expect(chunkPath(['1a', '2b'], separator)).toEqual(['1a.2b'])
+    expect(chunkPath(['a1b', 'c2d'], separator)).toEqual(['a1b.c2d'])
   })
 })

--- a/src/walker.test.ts
+++ b/src/walker.test.ts
@@ -851,14 +851,14 @@ describe('flatten', () => {
   test('should flatten object with objectsOnly set to true', () => {
     const obj = {
       a: { b: 23, c: 24 },
-      d: { e: 100, f: [10, 20, { g: 30, h: { i: 40 } }] },
+      d1: { e: 100, f: [10, 20, { g: 30, h: { i: 40 } }] },
     }
     const result = flatten(obj, { objectsOnly: true })
     expect(result).toEqual({
       'a.b': 23,
       'a.c': 24,
-      'd.e': 100,
-      'd.f': [10, 20, { g: 30, 'h.i': 40 }],
+      'd1.e': 100,
+      'd1.f': [10, 20, { g: 30, 'h.i': 40 }],
     })
   })
   test('should flatten array', () => {

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -283,7 +283,7 @@ export const findNode: FindNode = (obj, findFn, options = {}) => {
   return node
 }
 
-const chunkPath = (path: string[], separator: string) => {
+export const chunkPath = (path: string[], separator: string) => {
   let nestedPath: string[] = []
   const chunkedPath = []
   const addNestedPath = () => {
@@ -293,7 +293,8 @@ const chunkPath = (path: string[], separator: string) => {
     }
   }
   for (const key of path) {
-    if (/[0-9]+/.test(key)) {
+    const isKeyOnlyNumbers = /^[0-9]+$/.test(key)
+    if (isKeyOnlyNumbers) {
       addNestedPath()
       chunkedPath.push(key)
     } else {


### PR DESCRIPTION
## Summary
Fixed `chunkPath` to correctly handle alphanumeric keys.

Changing regex from `/[0-9]+/` to `/^[0-9]+$/` asserts to match only entirely numeric keys (e.g., "0", "123"), not keys containing numbers (e.g., "a1", "1a", "a1b")

